### PR TITLE
Update cosign, create helm namespace and align Gateway route to url path in binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 orbs:
   rust: twdps/rust-api@2.11.0
-  cosign: twdps/cosign@0.1.0
+  cosign: twdps/cosign@0.1.1
   kube: twdps/kube-ops@0.3.0
   op: twdps/onepassword@1.0.0
 
@@ -92,11 +92,13 @@ workflows:
           snyk-organization: twdps
           port-definition: "8000:8000"
           after-push:
-            - cosign/install
+            - cosign/install:
+                cosign-version: v2.2.1
             - cosign/sign:
                 registry: << pipeline.parameters.registry >>
                 image: lab-basic-bot
                 tag: dev.${CIRCLE_SHA1:0:7}
+                attestations: "--yes"
           filters: *on-push-main
 
   development-deploy-wip:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,7 @@ jobs:
             helm upgrade \
             --install \
             --namespace twdps-core-labs-team-<< parameters.environment >> \
+            --create-namespace
             --values deployment/values-<< parameters.environment >>.yaml \
             --cleanup-on-fail \
             --atomic \

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -31,7 +31,7 @@ spec:
     - name: "root"
       match:
         - uri:
-            prefix: "/v1/echo"
+            prefix: "/echo"
       route:
         - destination:
             host: {{ include "lab-basic-bot.fullname" . }}

--- a/chart/templates/tests/test-connection.yaml
+++ b/chart/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "lab-basic-bot.fullname" . }}:{{ .Values.service.port }}/v1/teams']
+      args: ['{{ include "lab-basic-bot.fullname" . }}:{{ .Values.service.port }}/echo']
   restartPolicy: Never


### PR DESCRIPTION
**Summary**

This PR
- explicitly specifies cosign version to install in the pipeline
- runs cosign/sign in non-interactive mode
- creates helm namespace on helm install
- aligns the Gateway route to the url path in the Rust binary